### PR TITLE
internal: fix panic on filenames without an extension

### DIFF
--- a/cmd/hbt/main.go
+++ b/cmd/hbt/main.go
@@ -62,6 +62,9 @@ func detectInputFormat(filename string) (Format, error) {
 	format, ok := internal.DetectInputFormat(filename)
 	if !ok {
 		ext := filepath.Ext(filename)
+		if ext == "" {
+			return Format{}, fmt.Errorf("cannot detect input format of %s: no file extension (use -f)", filename)
+		}
 		return Format{}, fmt.Errorf("no parser for extension: %s", ext)
 	}
 	return format, nil
@@ -71,6 +74,9 @@ func detectOutputFormat(filename string) (Format, error) {
 	format, ok := internal.DetectOutputFormat(filename)
 	if !ok {
 		ext := filepath.Ext(filename)
+		if ext == "" {
+			return Format{}, fmt.Errorf("cannot detect output format of %s: no file extension (use -t)", filename)
+		}
 		return Format{}, fmt.Errorf("no formatter for extension: %s", ext)
 	}
 	return format, nil

--- a/internal/formats.go
+++ b/internal/formats.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"fmt"
 	"io"
+	"path/filepath"
 	"strings"
 
 	"github.com/henrytill/hbt-go/internal/formatter"
@@ -98,7 +99,7 @@ func (f *Format) Set(value string) error {
 }
 
 func DetectInputFormat(filename string) (Format, bool) {
-	switch strings.ToLower(filename[strings.LastIndex(filename, "."):]) {
+	switch strings.ToLower(filepath.Ext(filename)) {
 	case ".html":
 		return HTML, true
 	case ".json":
@@ -113,7 +114,7 @@ func DetectInputFormat(filename string) (Format, bool) {
 }
 
 func DetectOutputFormat(filename string) (Format, bool) {
-	switch strings.ToLower(filename[strings.LastIndex(filename, "."):]) {
+	switch strings.ToLower(filepath.Ext(filename)) {
 	case ".html":
 		return HTML, true
 	case ".yaml":

--- a/internal/formats_test.go
+++ b/internal/formats_test.go
@@ -1,0 +1,53 @@
+package internal
+
+import "testing"
+
+func TestDetectInputFormat(t *testing.T) {
+	tests := []struct {
+		filename string
+		want     Format
+		found    bool
+	}{
+		{"bookmarks.html", HTML, true},
+		{"bookmarks.HTML", HTML, true},
+		{"posts.json", JSON, true},
+		{"posts.xml", XML, true},
+		{"notes.md", Markdown, true},
+		{"archive.tar.md", Markdown, true},
+		{"noextension", Format{}, false},
+		{"trailing.", Format{}, false},
+		{"file.txt", Format{}, false},
+		{"", Format{}, false},
+	}
+
+	for _, tt := range tests {
+		got, found := DetectInputFormat(tt.filename)
+		if got != tt.want || found != tt.found {
+			t.Errorf("DetectInputFormat(%q) = (%v, %v), want (%v, %v)",
+				tt.filename, got, found, tt.want, tt.found)
+		}
+	}
+}
+
+func TestDetectOutputFormat(t *testing.T) {
+	tests := []struct {
+		filename string
+		want     Format
+		found    bool
+	}{
+		{"out.html", HTML, true},
+		{"out.yaml", YAML, true},
+		{"out.YAML", YAML, true},
+		{"noextension", Format{}, false},
+		{"out.json", Format{}, false},
+		{"", Format{}, false},
+	}
+
+	for _, tt := range tests {
+		got, found := DetectOutputFormat(tt.filename)
+		if got != tt.want || found != tt.found {
+			t.Errorf("DetectOutputFormat(%q) = (%v, %v), want (%v, %v)",
+				tt.filename, got, found, tt.want, tt.found)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

`DetectInputFormat` and `DetectOutputFormat` sliced the filename at `strings.LastIndex(filename, ".")`, which returns -1 when the name contains no dot, so any extensionless filename crashed the CLI:

```
$ hbt noextension
panic: runtime error: slice bounds out of range [-1:]
```

## Changes

- Use `filepath.Ext` in both detection functions; it returns `""` for extensionless names, which falls through to the existing not-found path.
- When detection fails specifically because there is no extension, report a clearer error suggesting `-f`/`-t` instead of `no parser for extension: ` with a trailing blank.
- Add table-driven unit tests for both detection functions, covering the extensionless, trailing-dot, unknown-extension, and case-insensitivity cases.

## Testing

- `go test ./internal/` (new tests fail on the old code with the same panic)
- `make test` — full suite including the 37 CLI golden tests passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018cJAFQYxY1dkbd376Ahqtr

---
_Generated by [Claude Code](https://claude.ai/code/session_018cJAFQYxY1dkbd376Ahqtr)_