### PR TITLE
internal: fix bogus rejection of repeated format flags

### DIFF
--- a/cmd/hbt/main.go
+++ b/cmd/hbt/main.go
@@ -20,8 +20,8 @@ var (
 type Format = internal.Format
 
 type Config struct {
-	InputFormat  Format
-	OutputFormat Format
+	InputFormat  internal.FormatFlag
+	OutputFormat internal.FormatFlag
 	OutputFile   *string
 	Info         *bool
 	ListTags     *bool
@@ -78,8 +78,8 @@ func detectOutputFormat(filename string) (Format, error) {
 
 func main() {
 	config := Config{
-		InputFormat:  Format{Capability: internal.CapInput},
-		OutputFormat: Format{Capability: internal.CapOutput},
+		InputFormat:  internal.NewInputFormatFlag(),
+		OutputFormat: internal.NewOutputFormatFlag(),
 		OutputFile:   flag.String("o", "", "Output file (defaults to stdout)"),
 		Info:         flag.Bool("info", false, "Show collection info (entity count)"),
 		ListTags:     flag.Bool("list-tags", false, "List all tags"),
@@ -120,26 +120,26 @@ func main() {
 	config.InputFile = args[0]
 
 	// If no input format was specified, detect it from the filename
-	if config.InputFormat.Name == "" {
+	if config.InputFormat.Format.Name == "" {
 		format, err := detectInputFormat(config.InputFile)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 			os.Exit(1)
 		}
-		config.InputFormat = format
+		config.InputFormat.Format = format
 	}
 
 	// If no output format was specified, detect it from the output filename
-	if config.OutputFormat.Name == "" && *config.OutputFile != "" {
+	if config.OutputFormat.Format.Name == "" && *config.OutputFile != "" {
 		format, err := detectOutputFormat(*config.OutputFile)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 			os.Exit(1)
 		}
-		config.OutputFormat = format
+		config.OutputFormat.Format = format
 	}
 
-	if !*config.Info && !*config.ListTags && config.OutputFormat.Name == "" {
+	if !*config.Info && !*config.ListTags && config.OutputFormat.Format.Name == "" {
 		fmt.Fprintf(os.Stderr, "Error: Must specify an output format (-t) or analysis flag (--info, --list-tags)\n")
 		os.Exit(1)
 	}
@@ -156,7 +156,7 @@ func main() {
 	}
 	defer inputFile.Close()
 
-	coll, err := internal.Parse(config.InputFormat, inputFile)
+	coll, err := internal.Parse(config.InputFormat.Format, inputFile)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error parsing file: %v\n", err)
 		os.Exit(1)
@@ -192,7 +192,7 @@ func main() {
 		return
 	}
 
-	if config.OutputFormat.Name != "" {
+	if config.OutputFormat.Format.Name != "" {
 		var output *os.File
 		if *config.OutputFile != "" {
 			output, err = os.Create(*config.OutputFile)
@@ -205,7 +205,7 @@ func main() {
 			output = os.Stdout
 		}
 
-		err = internal.Unparse(config.OutputFormat, output, &coll)
+		err = internal.Unparse(config.OutputFormat.Format, output, &coll)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error formatting output: %v\n", err)
 			os.Exit(1)

--- a/internal/format_flag_test.go
+++ b/internal/format_flag_test.go
@@ -1,0 +1,62 @@
+package internal
+
+import "testing"
+
+func TestFormatFlagSet(t *testing.T) {
+	t.Run("output flag accepts repeated valid values", func(t *testing.T) {
+		f := NewOutputFormatFlag()
+		if err := f.Set("html"); err != nil {
+			t.Fatalf("Set(html): unexpected error: %v", err)
+		}
+		if err := f.Set("yaml"); err != nil {
+			t.Fatalf("Set(yaml) after Set(html): unexpected error: %v", err)
+		}
+		if f.Format != YAML {
+			t.Errorf("expected last value to win, got %v", f.Format)
+		}
+	})
+
+	t.Run("input flag accepts repeated valid values", func(t *testing.T) {
+		f := NewInputFormatFlag()
+		if err := f.Set("html"); err != nil {
+			t.Fatalf("Set(html): unexpected error: %v", err)
+		}
+		if err := f.Set("markdown"); err != nil {
+			t.Fatalf("Set(markdown) after Set(html): unexpected error: %v", err)
+		}
+		if f.Format != Markdown {
+			t.Errorf("expected last value to win, got %v", f.Format)
+		}
+	})
+
+	t.Run("input flag rejects output-only format", func(t *testing.T) {
+		f := NewInputFormatFlag()
+		if err := f.Set("yaml"); err == nil {
+			t.Error("expected error setting input flag to yaml")
+		}
+	})
+
+	t.Run("output flag rejects input-only format", func(t *testing.T) {
+		f := NewOutputFormatFlag()
+		if err := f.Set("markdown"); err == nil {
+			t.Error("expected error setting output flag to markdown")
+		}
+	})
+
+	t.Run("rejects unknown format", func(t *testing.T) {
+		f := NewInputFormatFlag()
+		if err := f.Set("csv"); err == nil {
+			t.Error("expected error for unknown format")
+		}
+	})
+
+	t.Run("is case-insensitive", func(t *testing.T) {
+		f := NewInputFormatFlag()
+		if err := f.Set("JSON"); err != nil {
+			t.Fatalf("Set(JSON): unexpected error: %v", err)
+		}
+		if f.Format != JSON {
+			t.Errorf("expected JSON, got %v", f.Format)
+		}
+	})
+}

--- a/internal/formats.go
+++ b/internal/formats.go
@@ -80,20 +80,33 @@ func parseFormat(name string) (Format, bool) {
 	return Format{}, false
 }
 
-func (f *Format) Set(value string) error {
+// FormatFlag is a flag.Value that parses a Format constrained to a fixed
+// role (input or output). The role is independent of the currently held
+// Format, so setting the flag repeatedly validates each value the same way.
+type FormatFlag struct {
+	Format Format
+	role   FormatCapability
+}
+
+func NewInputFormatFlag() FormatFlag  { return FormatFlag{role: CapInput} }
+func NewOutputFormatFlag() FormatFlag { return FormatFlag{role: CapOutput} }
+
+func (f *FormatFlag) String() string { return f.Format.Name }
+
+func (f *FormatFlag) Set(value string) error {
 	parsed, ok := parseFormat(value)
 	if !ok {
 		return fmt.Errorf("invalid format: %s", value)
 	}
 
-	if f.CanInput() && !parsed.CanInput() {
+	if f.role&CapInput != 0 && !parsed.CanInput() {
 		return fmt.Errorf("format %s cannot be used for input", value)
 	}
-	if f.CanOutput() && !parsed.CanOutput() {
+	if f.role&CapOutput != 0 && !parsed.CanOutput() {
 		return fmt.Errorf("format %s cannot be used for output", value)
 	}
 
-	*f = parsed
+	f.Format = parsed
 	return nil
 }
 


### PR DESCRIPTION
## Summary

`Format.Set` validated each new flag value against the capability of the `Format` *currently held* by the flag variable. The input/output role was encoded only in the initial sentinel value (`Format{Capability: CapInput}`), so after the first real assignment the sentinel was gone and subsequent occurrences were validated against the previous value's capability instead of the flag's role:

```
$ hbt -t html -t yaml bookmarks.json
invalid value "yaml" for flag -t: format yaml cannot be used for input
```

(`html` is `CapBoth`, so the second `-t` was checked as if it were an input flag.)

## Changes

- Replace the `Format.Set` flag mechanism with a `FormatFlag` type (`NewInputFormatFlag`/`NewOutputFormatFlag`) that stores the flag's role separately from the parsed format. Every occurrence is validated the same way, and the last value wins — standard flag semantics.
- Update `cmd/hbt` to use `FormatFlag` for `-f`/`--from` and `-t`/`--to`.
- Add unit tests covering repeated values on both flag roles, role violations in both directions, unknown formats, and case-insensitivity.

## Testing

- `go test ./internal/` — new tests; the repeated-value cases fail against the old code.
- `make test` — full suite including CLI golden tests passes; verified `hbt -t html -t yaml`, repeated `-f`, and invalid `-f yaml` manually against the built binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018cJAFQYxY1dkbd376Ahqtr

---
_Generated by [Claude Code](https://claude.ai/code/session_018cJAFQYxY1dkbd376Ahqtr)_