### PR TITLE
internal/parser: match toread bookmark tag exactly

### DIFF
--- a/internal/parser/html.go
+++ b/internal/parser/html.go
@@ -70,13 +70,15 @@ func add(
 	}
 
 	labels := make(map[types.Label]struct{})
-	if pending.tags != "" {
-		tagList := strings.SplitSeq(pending.tags, ",")
-		for tag := range tagList {
-			tag = strings.TrimSpace(tag)
-			if tag != "" && tag != "toread" {
-				labels[types.Label(tag)] = struct{}{}
-			}
+	hasToreadTag := false
+	for tag := range strings.SplitSeq(pending.tags, ",") {
+		tag = strings.TrimSpace(tag)
+		switch tag {
+		case "":
+		case "toread":
+			hasToreadTag = true
+		default:
+			labels[types.Label(tag)] = struct{}{}
 		}
 	}
 
@@ -92,7 +94,7 @@ func add(
 	var toRead types.ToRead
 	if pending.toRead != "" {
 		toRead = types.NewToRead(pending.toRead == "1")
-	} else if pending.tags != "" && strings.Contains(pending.tags, "toread") {
+	} else if hasToreadTag {
 		toRead = types.NewToRead(true)
 	}
 

--- a/internal/parser/html_test.go
+++ b/internal/parser/html_test.go
@@ -1,0 +1,82 @@
+package parser
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/henrytill/hbt-go/internal/types"
+)
+
+func parseSingleBookmark(t *testing.T, anchor string) types.Entity {
+	t.Helper()
+
+	doc := fmt.Sprintf(`<!DOCTYPE NETSCAPE-Bookmark-file-1>
+<DL><p>
+    <DT>%s
+</DL><p>
+`, anchor)
+
+	p := &HTMLParser{}
+	coll, err := p.Parse(strings.NewReader(doc))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if coll.Len() != 1 {
+		t.Fatalf("expected 1 entity, got %d", coll.Len())
+	}
+	return coll.Entities()[0]
+}
+
+func labelSet(e types.Entity) map[string]struct{} {
+	set := make(map[string]struct{})
+	for label := range e.Labels {
+		set[string(label)] = struct{}{}
+	}
+	return set
+}
+
+func TestHTMLParserToreadTag(t *testing.T) {
+	t.Run("exact toread tag sets flag and is dropped from labels", func(t *testing.T) {
+		e := parseSingleBookmark(t, `<A HREF="https://example.com/" ADD_DATE="100" TAGS="toread,go">Ex</A>`)
+
+		if toRead, ok := e.ToRead.Get(); !ok || !toRead {
+			t.Errorf("expected ToRead true, got (%v, %v)", toRead, ok)
+		}
+		labels := labelSet(e)
+		if _, exists := labels["toread"]; exists {
+			t.Error("toread should not appear as a label")
+		}
+		if _, exists := labels["go"]; !exists {
+			t.Error("expected go label to be kept")
+		}
+	})
+
+	t.Run("tag merely containing toread is a plain label", func(t *testing.T) {
+		e := parseSingleBookmark(t, `<A HREF="https://example.com/" ADD_DATE="100" TAGS="toreading,go">Ex</A>`)
+
+		if _, ok := e.ToRead.Get(); ok {
+			t.Error("ToRead should be unset for tag toreading")
+		}
+		labels := labelSet(e)
+		if _, exists := labels["toreading"]; !exists {
+			t.Error("expected toreading label to be kept")
+		}
+	})
+
+	t.Run("TOREAD attribute takes precedence over tags", func(t *testing.T) {
+		e := parseSingleBookmark(t, `<A HREF="https://example.com/" ADD_DATE="100" TAGS="toread" TOREAD="0">Ex</A>`)
+
+		if toRead, ok := e.ToRead.Get(); !ok || toRead {
+			t.Errorf("expected ToRead false from TOREAD attribute, got (%v, %v)", toRead, ok)
+		}
+	})
+
+	t.Run("TOREAD attribute set without tags", func(t *testing.T) {
+		e := parseSingleBookmark(t, `<A HREF="https://example.com/" ADD_DATE="100" TOREAD="1">Ex</A>`)
+
+		if toRead, ok := e.ToRead.Get(); !ok || !toRead {
+			t.Errorf("expected ToRead true from TOREAD attribute, got (%v, %v)", toRead, ok)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

The HTML parser decided the to-read flag with `strings.Contains(pending.tags, "toread")` over the raw comma-joined TAGS attribute, so any tag merely *containing* "toread" marked the bookmark as to-read. A bookmark tagged `toreading` came out as:

```yaml
labels:
- toreading
toRead: true    # wrong
```

The label filter, by contrast, only dropped an exact `toread` tag — so the two code paths also disagreed about which tags counted.

## Changes

- Detect the `toread` tag while splitting the TAGS attribute into labels, so both the label filtering and the to-read flag come from the same exact per-tag comparison. An exact `toread` tag still sets the flag and is dropped from labels; `toreading` is now just a label.
- The explicit `TOREAD` attribute still takes precedence over the tag, as before.
- Add the parser package's first unit tests, covering the tag/attribute combinations.

## Testing

- `go test ./internal/parser/` — the "tag merely containing toread" case fails against the old code.
- `make test` — full suite including CLI golden tests passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018cJAFQYxY1dkbd376Ahqtr

---
_Generated by [Claude Code](https://claude.ai/code/session_018cJAFQYxY1dkbd376Ahqtr)_