### PR TITLE
internal/formatter: escape HTML special characters in output

### DIFF
--- a/internal/formatter/html.go
+++ b/internal/formatter/html.go
@@ -10,8 +10,30 @@ import (
 	"github.com/henrytill/hbt-go/internal/types"
 )
 
+// attrEscaper escapes the characters that are unsafe inside the template's
+// double-quoted attribute values. textEscaper does the same for text content,
+// where quotes are safe and left alone. Neither escapes single quotes, both
+// because they are safe in these contexts and to keep output byte-identical
+// for existing bookmark files.
+var (
+	attrEscaper = strings.NewReplacer(
+		"&", "&amp;",
+		"<", "&lt;",
+		">", "&gt;",
+		`"`, "&quot;",
+	)
+	textEscaper = strings.NewReplacer(
+		"&", "&amp;",
+		"<", "&lt;",
+		">", "&gt;",
+	)
+)
+
 type HTMLFormatter struct{}
 
+// templateEntity holds the values interpolated into the bookmark template.
+// The string fields sourced from entity data (Href, Text, Tags, Extended)
+// are HTML-escaped by newTemplateEntity; the template must not escape again.
 type templateEntity struct {
 	Href         string
 	Text         string
@@ -54,7 +76,7 @@ func newTemplateEntity(entity types.Entity) templateEntity {
 
 	var extended *string
 	if len(entity.Extended) > 0 {
-		s := string(entity.Extended[0])
+		s := textEscaper.Replace(string(entity.Extended[0]))
 		extended = &s
 	}
 
@@ -74,10 +96,10 @@ func newTemplateEntity(entity types.Entity) templateEntity {
 	}
 
 	ret := templateEntity{
-		Href:      href,
-		Text:      text,
+		Href:      attrEscaper.Replace(href),
+		Text:      textEscaper.Replace(text),
 		AddDate:   entity.CreatedAt.Unix(),
-		Tags:      strings.Join(tags, ","),
+		Tags:      attrEscaper.Replace(strings.Join(tags, ",")),
 		Private:   private,
 		ToRead:    toRead,
 		Feed:      feed,

--- a/internal/formatter/html_test.go
+++ b/internal/formatter/html_test.go
@@ -1,0 +1,127 @@
+package formatter
+
+import (
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/henrytill/hbt-go/internal/parser"
+	"github.com/henrytill/hbt-go/internal/types"
+)
+
+func specialEntity(t *testing.T) types.Entity {
+	t.Helper()
+	u, err := url.Parse("https://example.com/?a=1&b=2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return types.Entity{
+		URI:       u,
+		CreatedAt: types.CreatedAt(time.Unix(100, 0)),
+		UpdatedAt: []types.UpdatedAt{},
+		Names: map[types.Name]struct{}{
+			types.Name(`Title with "quotes" & <markup>`): {},
+		},
+		Labels: map[types.Label]struct{}{
+			types.Label("tag&co"): {},
+		},
+		Extended: []types.Extended{
+			types.Extended(`description with <b>html</b> & "quotes"`),
+		},
+	}
+}
+
+func formatCollection(t *testing.T, coll *types.Collection) string {
+	t.Helper()
+	var buf strings.Builder
+	f := &HTMLFormatter{}
+	if err := f.Format(&buf, coll); err != nil {
+		t.Fatalf("Format: %v", err)
+	}
+	return buf.String()
+}
+
+func TestHTMLFormatterEscapesSpecialCharacters(t *testing.T) {
+	coll := types.NewCollection()
+	coll.Upsert(specialEntity(t))
+
+	out := formatCollection(t, &coll)
+
+	wantEscaped := []string{
+		`HREF="https://example.com/?a=1&amp;b=2"`,
+		`TAGS="tag&amp;co"`,
+		`>Title with "quotes" &amp; &lt;markup&gt;</A>`,
+		`<DD>description with &lt;b&gt;html&lt;/b&gt; &amp; "quotes"`,
+	}
+	for _, want := range wantEscaped {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q\noutput:\n%s", want, out)
+		}
+	}
+
+	wantAbsent := []string{
+		`&b=2"`,
+		`<markup>`,
+		`<b>html</b>`,
+	}
+	for _, unwanted := range wantAbsent {
+		if strings.Contains(out, unwanted) {
+			t.Errorf("output contains unescaped %q\noutput:\n%s", unwanted, out)
+		}
+	}
+}
+
+func TestHTMLFormatterPreservesSingleQuotes(t *testing.T) {
+	u, err := url.Parse("https://example.com/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	coll := types.NewCollection()
+	coll.Upsert(types.Entity{
+		URI:       u,
+		CreatedAt: types.CreatedAt(time.Unix(100, 0)),
+		Names:     map[types.Name]struct{}{types.Name("O'Reilly Radar"): {}},
+	})
+
+	out := formatCollection(t, &coll)
+
+	if !strings.Contains(out, ">O'Reilly Radar</A>") {
+		t.Errorf("single quotes should pass through unescaped\noutput:\n%s", out)
+	}
+}
+
+func TestHTMLFormatterRoundTrip(t *testing.T) {
+	coll := types.NewCollection()
+	original := specialEntity(t)
+	coll.Upsert(original)
+
+	out := formatCollection(t, &coll)
+
+	p := &parser.HTMLParser{}
+	reparsed, err := p.Parse(strings.NewReader(out))
+	if err != nil {
+		t.Fatalf("reparsing formatted output: %v", err)
+	}
+	if reparsed.Len() != 1 {
+		t.Fatalf("expected 1 entity after round trip, got %d", reparsed.Len())
+	}
+
+	got := reparsed.Entities()[0]
+	if got.URI.String() != original.URI.String() {
+		t.Errorf("URI: got %q, want %q", got.URI.String(), original.URI.String())
+	}
+	for name := range original.Names {
+		if _, ok := got.Names[name]; !ok {
+			t.Errorf("name %q lost in round trip, got %v", name, got.Names)
+		}
+	}
+	for label := range original.Labels {
+		if _, ok := got.Labels[label]; !ok {
+			t.Errorf("label %q lost in round trip, got %v", label, got.Labels)
+		}
+	}
+	if len(got.Extended) != 1 || got.Extended[0] != original.Extended[0] {
+		t.Errorf("extended: got %v, want %v", got.Extended, original.Extended)
+	}
+}


### PR DESCRIPTION
## Summary

The HTML formatter used `text/template` and interpolated entity data raw, so a title, tag, URL, or extended description containing `&`, `<`, `>`, or a double quote produced invalid markup: ampersands were emitted bare (`& markup`), a quote inside TAGS or HREF corrupted the attribute, and markup-like text was injected verbatim. Round-tripping such a collection through the HTML format was lossy.

## Changes

- Escape values when building the template data, context-sensitively:
  - **attribute values** (HREF, TAGS): escape `&`, `<`, `>`, `"`
  - **text content** (anchor text, `<DD>` descriptions): escape `&`, `<`, `>`; double quotes are safe there and pass through
- Single quotes pass through in both contexts. Together this keeps output byte-identical for existing bookmark files — the golden suite (which contains both `O'Reilly Radar` and literal `PRIVATE="0"` text in a `<DD>`) passes unchanged.
- Add the formatter package's first unit tests: escaping in each context, single-quote preservation, and a full format→parse round trip verifying no data is lost.

**Why not `html/template`:** its URL sanitizer rewrites non-http(s) schemes (`ftp:`, `gopher:`, …) to `#ZgotmplZ`, which a bookmark tool must not do.

## Testing

- `go test ./internal/formatter/` — new tests; the escaping and round-trip cases fail against the old code.
- `make test` — full suite including CLI golden tests passes byte-for-byte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018cJAFQYxY1dkbd376Ahqtr

---
_Generated by [Claude Code](https://claude.ai/code/session_018cJAFQYxY1dkbd376Ahqtr)_