### PR TITLE
internal/types: validate collection data when deserializing

### DIFF
--- a/internal/types/collection.go
+++ b/internal/types/collection.go
@@ -199,9 +199,6 @@ func (c *Collection) fromRepr(s collectionRepr) error {
 		if err := entity.fromRepr(serNode.Entity); err != nil {
 			return fmt.Errorf("node %d: %w", i, err)
 		}
-		if entity.URI == nil {
-			return fmt.Errorf("node %d: missing uri", i)
-		}
 		for _, edge := range serNode.Edges {
 			if edge >= uint(length) {
 				return fmt.Errorf("node %d: edge %d out of range [0, %d)", i, edge, length)

--- a/internal/types/collection.go
+++ b/internal/types/collection.go
@@ -182,6 +182,14 @@ func (c *Collection) fromRepr(s collectionRepr) error {
 	}
 
 	length := len(s.Value)
+	if s.Length != uint(length) {
+		return fmt.Errorf(
+			"length mismatch in serialized data: declared %d, got %d nodes",
+			s.Length,
+			length,
+		)
+	}
+
 	c.entities = make([]Entity, length)
 	c.edges = make([][]uint, length)
 	c.urls = make(map[string]uint)
@@ -189,7 +197,15 @@ func (c *Collection) fromRepr(s collectionRepr) error {
 	for i, serNode := range s.Value {
 		var entity Entity
 		if err := entity.fromRepr(serNode.Entity); err != nil {
-			return err
+			return fmt.Errorf("node %d: %w", i, err)
+		}
+		if entity.URI == nil {
+			return fmt.Errorf("node %d: missing uri", i)
+		}
+		for _, edge := range serNode.Edges {
+			if edge >= uint(length) {
+				return fmt.Errorf("node %d: edge %d out of range [0, %d)", i, edge, length)
+			}
 		}
 		c.entities[i] = entity
 		if serNode.Edges != nil {

--- a/internal/types/collection_repr_test.go
+++ b/internal/types/collection_repr_test.go
@@ -1,0 +1,142 @@
+package types
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/goccy/go-yaml"
+)
+
+func makeReprTestCollection(t *testing.T) Collection {
+	t.Helper()
+
+	coll := NewCollection()
+
+	parent := Entity{
+		URI:           mustParseURL("https://example.com/parent"),
+		CreatedAt:     CreatedAt(time.Unix(100, 0)),
+		UpdatedAt:     []UpdatedAt{UpdatedAt(time.Unix(200, 0))},
+		Names:         map[Name]struct{}{"Parent": {}},
+		Labels:        map[Label]struct{}{"a": {}, "b": {}},
+		Shared:        NewShared(true),
+		ToRead:        NewToRead(false),
+		IsFeed:        NewIsFeed(false),
+		Extended:      []Extended{"extended text"},
+		LastVisitedAt: NewLastVisitedAt(time.Unix(300, 0)),
+	}
+	child := Entity{
+		URI:       mustParseURL("https://example.com/child"),
+		CreatedAt: CreatedAt(time.Unix(150, 0)),
+		UpdatedAt: []UpdatedAt{},
+		Names:     map[Name]struct{}{"Child": {}},
+		Labels:    map[Label]struct{}{},
+	}
+
+	parentID := coll.Upsert(parent)
+	childID := coll.Upsert(child)
+	coll.AddEdges(childID, parentID)
+
+	return coll
+}
+
+func TestCollectionJSONRoundTrip(t *testing.T) {
+	coll := makeReprTestCollection(t)
+
+	first, err := json.Marshal(&coll)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	var got Collection
+	if err := json.Unmarshal(first, &got); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if got.Len() != coll.Len() {
+		t.Fatalf("Len after round trip: got %d, want %d", got.Len(), coll.Len())
+	}
+
+	second, err := json.Marshal(&got)
+	if err != nil {
+		t.Fatalf("Marshal after round trip: %v", err)
+	}
+	if !bytes.Equal(first, second) {
+		t.Errorf("round trip not stable:\nfirst:  %s\nsecond: %s", first, second)
+	}
+}
+
+func TestCollectionYAMLRoundTrip(t *testing.T) {
+	coll := makeReprTestCollection(t)
+
+	first, err := yaml.Marshal(&coll)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	var got Collection
+	if err := yaml.Unmarshal(first, &got); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if got.Len() != coll.Len() {
+		t.Fatalf("Len after round trip: got %d, want %d", got.Len(), coll.Len())
+	}
+
+	second, err := yaml.Marshal(&got)
+	if err != nil {
+		t.Fatalf("Marshal after round trip: %v", err)
+	}
+	if !bytes.Equal(first, second) {
+		t.Errorf("round trip not stable:\nfirst:  %s\nsecond: %s", first, second)
+	}
+}
+
+func TestCollectionUnmarshalMalformed(t *testing.T) {
+	tests := []struct {
+		name    string
+		data    string
+		wantErr string
+	}{
+		{
+			name: "missing uri",
+			data: `{"version":"0.1.0","length":1,"value":[
+				{"id":0,"entity":{"uri":"","createdAt":100,"updatedAt":[],"names":[],"labels":[]},"edges":[]}]}`,
+			wantErr: "missing uri",
+		},
+		{
+			name: "edge out of range",
+			data: `{"version":"0.1.0","length":1,"value":[
+				{"id":0,"entity":{"uri":"https://example.com/","createdAt":100,"updatedAt":[],"names":[],"labels":[]},"edges":[7]}]}`,
+			wantErr: "out of range",
+		},
+		{
+			name:    "length mismatch",
+			data:    `{"version":"0.1.0","length":3,"value":[]}`,
+			wantErr: "length mismatch",
+		},
+		{
+			name:    "invalid version",
+			data:    `{"version":"bogus","length":0,"value":[]}`,
+			wantErr: "invalid version",
+		},
+		{
+			name:    "incompatible version",
+			data:    `{"version":"9.9.9","length":0,"value":[]}`,
+			wantErr: "incompatible version",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var coll Collection
+			err := json.Unmarshal([]byte(tt.data), &coll)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("error %q does not contain %q", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/types/entity.go
+++ b/internal/types/entity.go
@@ -270,15 +270,14 @@ func (e Entity) toRepr() entityRepr {
 }
 
 func (e *Entity) fromRepr(s entityRepr) error {
-	if s.URI != "" {
-		parsedURL, err := url.Parse(s.URI)
-		if err != nil {
-			return err
-		}
-		e.URI = parsedURL
-	} else {
-		e.URI = nil
+	if s.URI == "" {
+		return fmt.Errorf("missing uri")
 	}
+	parsedURL, err := url.Parse(s.URI)
+	if err != nil {
+		return err
+	}
+	e.URI = parsedURL
 
 	e.CreatedAt = CreatedAt(time.Unix(s.CreatedAt, 0))
 


### PR DESCRIPTION
## Summary

Deserializing a collection trusted its input in three ways:

- a node with an empty `uri` left `Entity.URI` nil, then crashed with a nil pointer dereference on `entity.URI.String()` while building the `urls` index
- edge indices were stored without bounds checking, producing silently corrupt collections
- the declared `length` field was decoded but never compared against the actual node count

Neither `UnmarshalYAML` nor `UnmarshalJSON` has production callers yet, so the panic wasn't reachable from the CLI — but this is the deserialization half of the repr API (symmetric with the marshal side that backs the YAML output format), and it should fail cleanly on malformed data before it grows callers.

## Changes

- `Entity.fromRepr` rejects a missing/empty `uri` — the URI is the entity's identity key and every producer requires one, so the check lives at the entity level (per review).
- `Collection.fromRepr` returns errors for an edge index `>= length` and a `length`/node-count mismatch, and wraps per-node entity errors with the node index.
- Add the repr layer's first tests:
  - marshal → unmarshal → marshal round trips through both JSON and YAML (byte-stable, exercising edges, names, labels, tri-state flags, extended, lastVisitedAt)
  - malformed-input cases: missing uri, out-of-range edge, length mismatch, invalid version, incompatible version

## Testing

- `go test ./internal/types/` — verified the missing-uri case **panics** against the old code (nil pointer dereference) and fails cleanly with an error after the fix.
- `make test` — full suite including CLI golden tests passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018cJAFQYxY1dkbd376Ahqtr