### PR TITLE
internal/client/pinboard: bound 429 retries and honor Retry-After

### DIFF
--- a/internal/client/pinboard/client.go
+++ b/internal/client/pinboard/client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strconv"
 	"time"
 )
 
@@ -14,6 +15,14 @@ const (
 	RateLimit       = 3 * time.Second
 	RatePostsAll    = 5 * time.Minute
 	RatePostsRecent = 1 * time.Minute
+
+	// maxRetries429 is the number of times a request is retried after a
+	// 429 response before giving up.
+	maxRetries429 = 3
+	// defaultRetryDelay is the base delay before retrying a 429 response;
+	// it doubles on each subsequent retry unless the response carries a
+	// Retry-After header.
+	defaultRetryDelay = 5 * time.Second
 )
 
 type AuthMethod interface {
@@ -44,6 +53,7 @@ type Client struct {
 	httpClient      *http.Client
 	auth            AuthMethod
 	baseURL         string
+	retryDelay      time.Duration
 	lastRequest     time.Time
 	lastPostsAll    time.Time
 	lastPostsRecent time.Time
@@ -54,6 +64,7 @@ func NewClient(auth AuthMethod) *Client {
 		httpClient: &http.Client{Timeout: 30 * time.Second},
 		auth:       auth,
 		baseURL:    BaseURL,
+		retryDelay: defaultRetryDelay,
 	}
 }
 
@@ -111,36 +122,47 @@ func (c *Client) makeRequest(ctx context.Context, endpoint string, params url.Va
 		reqURL += "?" + params.Encode()
 	}
 
-	req, err := http.NewRequestWithContext(ctx, "GET", reqURL, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	c.auth.Apply(req)
-
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return nil, err
-	}
-
-	if resp.StatusCode == 429 {
-		resp.Body.Close()
-
-		backoff := 5 * time.Second
-		select {
-		case <-time.After(backoff):
-			return c.makeRequest(ctx, endpoint, params)
-		case <-ctx.Done():
-			return nil, ctx.Err()
+	for attempt := 0; ; attempt++ {
+		req, err := http.NewRequestWithContext(ctx, "GET", reqURL, nil)
+		if err != nil {
+			return nil, err
 		}
-	}
 
-	if resp.StatusCode != 200 {
-		resp.Body.Close()
-		return nil, fmt.Errorf("API request failed with status %d", resp.StatusCode)
-	}
+		c.auth.Apply(req)
 
-	return resp, nil
+		resp, err := c.httpClient.Do(req)
+		if err != nil {
+			return nil, err
+		}
+
+		if resp.StatusCode == http.StatusTooManyRequests {
+			retryAfter := resp.Header.Get("Retry-After")
+			resp.Body.Close()
+
+			if attempt == maxRetries429 {
+				return nil, fmt.Errorf("API request rate limited (status 429) after %d attempts", attempt+1)
+			}
+
+			backoff := c.retryDelay << attempt
+			if secs, err := strconv.Atoi(retryAfter); err == nil && secs >= 0 {
+				backoff = time.Duration(secs) * time.Second
+			}
+
+			select {
+			case <-time.After(backoff):
+				continue
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			resp.Body.Close()
+			return nil, fmt.Errorf("API request failed with status %d", resp.StatusCode)
+		}
+
+		return resp, nil
+	}
 }
 
 func (c *Client) GetAPIToken(ctx context.Context) (string, error) {

--- a/internal/client/pinboard/client_test.go
+++ b/internal/client/pinboard/client_test.go
@@ -96,6 +96,66 @@ func TestMakeRequestRateLimit429(t *testing.T) {
 	auth := TokenAuth{Username: "test", Token: "token123"}
 	client := NewClient(auth)
 	client.baseURL = server.URL
+	client.retryDelay = 10 * time.Millisecond
+
+	resp, err := client.makeRequest(context.Background(), "test/endpoint", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if callCount != 2 {
+		t.Errorf("expected 2 calls (429 then success), got %d", callCount)
+	}
+}
+
+func TestMakeRequestRateLimit429Exhausted(t *testing.T) {
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	auth := TokenAuth{Username: "test", Token: "token123"}
+	client := NewClient(auth)
+	client.baseURL = server.URL
+	client.retryDelay = time.Millisecond
+
+	_, err := client.makeRequest(context.Background(), "test/endpoint", nil)
+	if err == nil {
+		t.Fatal("expected error after exhausting retries, got nil")
+	}
+	if !strings.Contains(err.Error(), "rate limited") {
+		t.Errorf("expected rate limited error, got: %v", err)
+	}
+
+	wantCalls := maxRetries429 + 1
+	if callCount != wantCalls {
+		t.Errorf("expected %d calls (initial + %d retries), got %d", wantCalls, maxRetries429, callCount)
+	}
+}
+
+func TestMakeRequestRateLimit429RetryAfter(t *testing.T) {
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		if callCount == 1 {
+			w.Header().Set("Retry-After", "0")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"result": "success"}`))
+	}))
+	defer server.Close()
+
+	auth := TokenAuth{Username: "test", Token: "token123"}
+	client := NewClient(auth)
+	client.baseURL = server.URL
+	// A Retry-After of 0 seconds must override the configured delay; if it
+	// does not, this test times out rather than finishing instantly.
+	client.retryDelay = time.Hour
 
 	start := time.Now()
 	resp, err := client.makeRequest(context.Background(), "test/endpoint", nil)
@@ -109,9 +169,37 @@ func TestMakeRequestRateLimit429(t *testing.T) {
 	if callCount != 2 {
 		t.Errorf("expected 2 calls (429 then success), got %d", callCount)
 	}
+	if elapsed > 10*time.Second {
+		t.Errorf("Retry-After: 0 should retry immediately, took %v", elapsed)
+	}
+}
 
-	if elapsed < 5*time.Second {
-		t.Errorf("expected at least 5s delay for 429 retry, got %v", elapsed)
+func TestMakeRequestRateLimit429ContextCanceled(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	auth := TokenAuth{Username: "test", Token: "token123"}
+	client := NewClient(auth)
+	client.baseURL = server.URL
+	client.retryDelay = time.Hour
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		_, err := client.makeRequest(ctx, "test/endpoint", nil)
+		done <- err
+	}()
+	cancel()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected error from canceled context, got nil")
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("makeRequest did not return promptly after context cancellation")
 	}
 }
 


### PR DESCRIPTION
## Summary

A 429 response triggered an unconditional recursive retry with a fixed 5-second sleep: a persistently rate-limited endpoint retried forever, and the caller never got an error.

## Changes

- Convert the recursion in `makeRequest` into a loop capped at **3 retries** with exponential backoff (5s → 10s → 20s by default).
- Honor a `Retry-After` header (seconds form) when the server sends one, overriding the computed backoff.
- Return a clear error (`API request rate limited (status 429) after 4 attempts`) when retries are exhausted, instead of hanging.
- Make the base delay an unexported `Client` field (defaulting to 5s) so tests can shrink it: the existing 429 test no longer sleeps 5 real seconds, dropping the package test time from ~5s to ~0.04s.
- New tests: retry-then-success, retry exhaustion (verifies exactly `1 + maxRetries` requests), `Retry-After: 0` overriding a deliberately huge configured delay, and prompt return on context cancellation during backoff.

## Testing

- `go test ./internal/client/...` — all pass in 0.04s.
- `make test` — full suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018cJAFQYxY1dkbd376Ahqtr

---
_Generated by [Claude Code](https://claude.ai/code/session_018cJAFQYxY1dkbd376Ahqtr)_