### PR TITLE
internal/client/pinboard: make rate limiting context-aware and accurate

### DIFF
--- a/internal/client/pinboard/client.go
+++ b/internal/client/pinboard/client.go
@@ -87,30 +87,54 @@ func (c *Client) WithHTTPClient(client *http.Client) *Client {
 	return c
 }
 
-func (c *Client) rateLimit(endpoint string) {
-	now := time.Now()
+// rateLimit waits until the endpoint's minimum request interval has passed,
+// returning early with the context's error if it is canceled first. The
+// per-endpoint and general intervals are enforced from the time the previous
+// request was actually released, not from when its rateLimit call started.
+// Client is not safe for concurrent use; callers must serialize requests.
+func (c *Client) rateLimit(ctx context.Context, endpoint string) error {
+	var wait time.Duration
 
 	switch endpoint {
 	case "posts/all":
-		if elapsed := now.Sub(c.lastPostsAll); elapsed < RatePostsAll {
-			time.Sleep(RatePostsAll - elapsed)
+		if elapsed := time.Since(c.lastPostsAll); elapsed < RatePostsAll {
+			wait = RatePostsAll - elapsed
 		}
-		c.lastPostsAll = now
 	case "posts/recent":
-		if elapsed := now.Sub(c.lastPostsRecent); elapsed < RatePostsRecent {
-			time.Sleep(RatePostsRecent - elapsed)
+		if elapsed := time.Since(c.lastPostsRecent); elapsed < RatePostsRecent {
+			wait = RatePostsRecent - elapsed
 		}
-		c.lastPostsRecent = now
 	}
 
-	if elapsed := now.Sub(c.lastRequest); elapsed < RateLimit {
-		time.Sleep(RateLimit - elapsed)
+	if elapsed := time.Since(c.lastRequest); elapsed < RateLimit {
+		wait = max(wait, RateLimit-elapsed)
 	}
-	c.lastRequest = time.Now()
+
+	if wait > 0 {
+		timer := time.NewTimer(wait)
+		defer timer.Stop()
+		select {
+		case <-timer.C:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+
+	now := time.Now()
+	switch endpoint {
+	case "posts/all":
+		c.lastPostsAll = now
+	case "posts/recent":
+		c.lastPostsRecent = now
+	}
+	c.lastRequest = now
+	return nil
 }
 
 func (c *Client) makeRequest(ctx context.Context, endpoint string, params url.Values) (*http.Response, error) {
-	c.rateLimit(endpoint)
+	if err := c.rateLimit(ctx, endpoint); err != nil {
+		return nil, err
+	}
 
 	reqURL := fmt.Sprintf("%s/%s", c.baseURL, endpoint)
 	if params == nil {

--- a/internal/client/pinboard/client_test.go
+++ b/internal/client/pinboard/client_test.go
@@ -357,3 +357,91 @@ func TestGetRecentPostsWithMultipleTags(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
+
+func TestRateLimitFreshClientDoesNotWait(t *testing.T) {
+	client := NewClient(TokenAuth{Username: "test", Token: "token123"})
+
+	start := time.Now()
+	if err := client.rateLimit(context.Background(), "posts/all"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Errorf("fresh client should not wait, took %v", elapsed)
+	}
+
+	if client.lastPostsAll.IsZero() || client.lastRequest.IsZero() {
+		t.Error("expected timestamps to be recorded")
+	}
+}
+
+func TestRateLimitRecordsTimeAfterWait(t *testing.T) {
+	client := NewClient(TokenAuth{Username: "test", Token: "token123"})
+
+	// Backdate the last posts/all request so ~100ms of its interval remains.
+	wait := 100 * time.Millisecond
+	client.lastPostsAll = time.Now().Add(-RatePostsAll + wait)
+	client.lastRequest = client.lastPostsAll
+
+	start := time.Now()
+	if err := client.rateLimit(context.Background(), "posts/all"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if elapsed := time.Since(start); elapsed < wait-10*time.Millisecond {
+		t.Errorf("expected to wait ~%v, only waited %v", wait, elapsed)
+	}
+
+	// The timestamp must reflect when the request was released (after the
+	// wait), not when rateLimit was called; otherwise the next interval is
+	// measured from too early and under-waits.
+	if recorded := client.lastPostsAll; recorded.Before(start.Add(wait - 10*time.Millisecond)) {
+		t.Errorf("lastPostsAll recorded pre-wait: %v is before %v", recorded, start.Add(wait))
+	}
+}
+
+func TestRateLimitContextCanceled(t *testing.T) {
+	client := NewClient(TokenAuth{Username: "test", Token: "token123"})
+
+	// Force a pending wait of the full posts/all interval (5 minutes).
+	mark := time.Now()
+	client.lastPostsAll = mark
+	client.lastRequest = mark
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	start := time.Now()
+	err := client.rateLimit(ctx, "posts/all")
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected error from canceled context, got nil")
+	}
+	if elapsed > time.Second {
+		t.Errorf("canceled context should return promptly, took %v", elapsed)
+	}
+
+	// A wait that was aborted must not count as a released request.
+	if !client.lastPostsAll.Equal(mark) || !client.lastRequest.Equal(mark) {
+		t.Error("timestamps should not be updated when the wait is aborted")
+	}
+}
+
+func TestMakeRequestRateLimitContextCanceled(t *testing.T) {
+	client := NewClient(TokenAuth{Username: "test", Token: "token123"})
+	client.lastRequest = time.Now()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	start := time.Now()
+	_, err := client.makeRequest(ctx, "posts/get", nil)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected error from canceled context, got nil")
+	}
+	if elapsed > time.Second {
+		t.Errorf("canceled context should abort the rate-limit wait promptly, took %v", elapsed)
+	}
+}


### PR DESCRIPTION
## Summary

The rate limiter had three problems:

- it slept with bare `time.Sleep`, so a canceled context still waited out the full interval (up to 5 minutes for `posts/all`) before the request even started — the 429 path already did the `select` on `ctx.Done()` correctly, but the rate limiter didn't
- it recorded `lastPostsAll`/`lastRequest` **before** sleeping, measuring intervals from call time rather than from when the previous request was actually released, so successive throttled calls under-waited
- it applied the endpoint-specific and general waits sequentially, sleeping up to their **sum** instead of their max

## Changes

- `rateLimit` now takes the context and returns an error: it computes the single combined wait (max of the endpoint interval and the general 3s interval), blocks on a timer/`ctx.Done()` select, and records timestamps only **after** the wait completes. An aborted wait does not count as a released request, so timestamps stay untouched on cancellation.
- Documented on `rateLimit` that `Client` is not safe for concurrent use (it wasn't before either — the timing state has no synchronization).

## Testing

New tests in `client_test.go`:

- fresh client doesn't wait and records timestamps
- a backdated interval waits the remaining ~100ms and records the **post-wait** time (fails against the old pre-sleep recording)
- a canceled context aborts a pending 5-minute wait promptly, via both `rateLimit` directly and `makeRequest`, leaving timestamps unchanged

`make test` — full suite passes.

Rebased atop `master` after #36 merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018cJAFQYxY1dkbd376Ahqtr