### PR TITLE
internal/client/pinboard: send toread=no when explicitly disabled

### DIFF
--- a/internal/client/pinboard/posts.go
+++ b/internal/client/pinboard/posts.go
@@ -136,6 +136,19 @@ type AddPostOptions struct {
 	ToRead   *bool
 }
 
+// setYesNo sets a Pinboard yes/no parameter from an optional bool: nil
+// leaves the parameter unset so the API default applies.
+func setYesNo(params url.Values, key string, value *bool) {
+	if value == nil {
+		return
+	}
+	if *value {
+		params.Set(key, "yes")
+	} else {
+		params.Set(key, "no")
+	}
+}
+
 func (c *Client) AddPost(ctx context.Context, urlParam, description string, opts *AddPostOptions) error {
 	params := url.Values{}
 	params.Set("url", urlParam)
@@ -151,25 +164,9 @@ func (c *Client) AddPost(ctx context.Context, urlParam, description string, opts
 		if !opts.Dt.IsZero() {
 			params.Set("dt", opts.Dt.Format(time.RFC3339))
 		}
-		if opts.Replace != nil {
-			if *opts.Replace {
-				params.Set("replace", "yes")
-			} else {
-				params.Set("replace", "no")
-			}
-		}
-		if opts.Shared != nil {
-			if *opts.Shared {
-				params.Set("shared", "yes")
-			} else {
-				params.Set("shared", "no")
-			}
-		}
-		if opts.ToRead != nil {
-			if *opts.ToRead {
-				params.Set("toread", "yes")
-			}
-		}
+		setYesNo(params, "replace", opts.Replace)
+		setYesNo(params, "shared", opts.Shared)
+		setYesNo(params, "toread", opts.ToRead)
 	}
 
 	resp, err := c.makeRequest(ctx, "posts/add", params)

--- a/internal/client/pinboard/posts_test.go
+++ b/internal/client/pinboard/posts_test.go
@@ -1,0 +1,65 @@
+package pinboard
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestAddPostExplicitFalseOptions(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		query := r.URL.Query()
+
+		if query.Get("replace") != "no" {
+			t.Errorf("expected replace=no, got %q", query.Get("replace"))
+		}
+		if query.Get("shared") != "no" {
+			t.Errorf("expected shared=no, got %q", query.Get("shared"))
+		}
+		if query.Get("toread") != "no" {
+			t.Errorf("expected toread=no, got %q", query.Get("toread"))
+		}
+
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"result_code": "done"}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(TokenAuth{Username: "test", Token: "token123"})
+	client.baseURL = server.URL
+
+	off := false
+	opts := &AddPostOptions{
+		Replace: &off,
+		Shared:  &off,
+		ToRead:  &off,
+	}
+
+	if err := client.AddPost(context.Background(), "https://example.com", "Test", opts); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestAddPostUnsetOptionsOmitted(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		query := r.URL.Query()
+
+		for _, key := range []string{"replace", "shared", "toread"} {
+			if query.Has(key) {
+				t.Errorf("expected %s to be omitted, got %q", key, query.Get(key))
+			}
+		}
+
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"result_code": "done"}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(TokenAuth{Username: "test", Token: "token123"})
+	client.baseURL = server.URL
+
+	if err := client.AddPost(context.Background(), "https://example.com", "Test", &AddPostOptions{}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

`AddPost` sent `replace=no` and `shared=no` when those options were explicitly false, but silently dropped an explicit `ToRead: &false` instead of sending `toread=no` — the three optional yes/no parameters didn't behave the same way, and an explicit "no" was indistinguishable from "unset".

## Changes

- Extract a `setYesNo` helper for the three optional yes/no parameters so they behave identically: `nil` leaves the parameter unset (API default applies), an explicit value is always sent as `yes`/`no`. Removes the triplicated conditional blocks.
- New tests: all three params explicitly false → all sent as `no`; all three unset → all omitted from the query.

## Testing

- `go test ./internal/client/...` — the explicit-false case fails against the old code (`toread` was omitted).
- `make test` — full suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018cJAFQYxY1dkbd376Ahqtr

---
_Generated by [Claude Code](https://claude.ai/code/session_018cJAFQYxY1dkbd376Ahqtr)_