### PR TITLE
internal/client/pinboard: escape note ID in request path

### DIFF
--- a/internal/client/pinboard/notes.go
+++ b/internal/client/pinboard/notes.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
 
 	"github.com/henrytill/hbt-go/internal/pinboard"
 )
@@ -29,7 +30,11 @@ func (c *Client) ListNotes(ctx context.Context) ([]Note, error) {
 }
 
 func (c *Client) GetNote(ctx context.Context, noteID string) (*Note, error) {
-	endpoint := fmt.Sprintf("notes/%s", noteID)
+	if noteID == "" {
+		return nil, fmt.Errorf("note ID is required")
+	}
+
+	endpoint := fmt.Sprintf("notes/%s", url.PathEscape(noteID))
 
 	resp, err := c.makeRequest(ctx, endpoint, nil)
 	if err != nil {

--- a/internal/client/pinboard/notes_test.go
+++ b/internal/client/pinboard/notes_test.go
@@ -1,0 +1,60 @@
+package pinboard
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestGetNote(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Path; got != "/notes/abc123" {
+			t.Errorf("expected path /notes/abc123, got %q", got)
+		}
+
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"id": "abc123", "title": "Test Note"}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(TokenAuth{Username: "test", Token: "token123"})
+	client.baseURL = server.URL
+
+	note, err := client.GetNote(context.Background(), "abc123")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if note.ID != "abc123" || note.Title != "Test Note" {
+		t.Errorf("unexpected note: %+v", note)
+	}
+}
+
+func TestGetNoteEscapesID(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// The raw (escaped) path must keep the entire ID inside the notes/
+		// segment; an unescaped slash would change the requested endpoint.
+		if got := r.URL.EscapedPath(); got != "/notes/..%2Fposts%2Fupdate" {
+			t.Errorf("expected escaped path /notes/..%%2Fposts%%2Fupdate, got %q", got)
+		}
+
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"id": "weird"}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(TokenAuth{Username: "test", Token: "token123"})
+	client.baseURL = server.URL
+
+	if _, err := client.GetNote(context.Background(), "../posts/update"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestGetNoteEmptyID(t *testing.T) {
+	client := NewClient(TokenAuth{Username: "test", Token: "token123"})
+
+	if _, err := client.GetNote(context.Background(), ""); err == nil {
+		t.Fatal("expected error for empty note ID, got nil")
+	}
+}


### PR DESCRIPTION
## Summary

`GetNote` interpolated the caller-supplied note ID into the endpoint path verbatim (`fmt.Sprintf("notes/%s", noteID)`), so an ID containing a slash or dot segments changed which endpoint the request hit — e.g. `GetNote(ctx, "../posts/update")` requested `posts/update` instead of anything under `notes/`.

## Changes

- Escape the ID with `url.PathEscape` so it always stays a single path segment.
- Reject an empty ID with an error instead of requesting `notes/`.
- Tests: normal ID, an ID containing `../` (asserts the escaped path stays inside `notes/`), and the empty-ID error.

## Testing

- `go test ./internal/client/...` — the escaping test fails against the old code.
- `make test` — full suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018cJAFQYxY1dkbd376Ahqtr

---
_Generated by [Claude Code](https://claude.ai/code/session_018cJAFQYxY1dkbd376Ahqtr)_