### PR TITLE
test: refuse to generate an empty test suite

### DIFF
--- a/test/testgen.go
+++ b/test/testgen.go
@@ -211,6 +211,14 @@ func main() {
 		log.Fatalf("Error finding test cases: %v", err)
 	}
 
+	if len(testCases) == 0 {
+		log.Fatalf(
+			"No test cases found in %s; refusing to overwrite %s with an empty test suite (is the testdata submodule initialized? try: git submodule update --init)",
+			testDataDir,
+			outputFile,
+		)
+	}
+
 	if err := generateTestFile(outputFile, testCases); err != nil {
 		log.Fatalf("Error generating test file: %v", err)
 	}


### PR DESCRIPTION
## Summary

When the `testdata` submodule is missing or empty, `go generate ./test` happily reported `Generated 0 test cases in cli_test.go` and overwrote `cli_test.go` with a file containing no tests — so `go test` passed vacuously with the entire golden suite silently gone. (I hit this live in a fresh clone without submodules.)

## Changes

`testgen` now fails **before** writing the output file when it finds zero test cases, with a message pointing at the likely cause:

```
No test cases found in testdata; refusing to overwrite cli_test.go with an empty
test suite (is the testdata submodule initialized? try: git submodule update --init)
```

## Testing

Verified manually both ways:

- with `test/testdata` empty: `go generate ./test` exits 1 with the message above and `cli_test.go` is left untouched (byte-identical to before)
- with the submodule initialized: generates the usual 37 test cases and `make test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018cJAFQYxY1dkbd376Ahqtr

---
_Generated by [Claude Code](https://claude.ai/code/session_018cJAFQYxY1dkbd376Ahqtr)_