### PR TITLE
internal/client/pinboard: return recommended tags from SuggestTags

### DIFF
--- a/internal/client/pinboard/endpoints_test.go
+++ b/internal/client/pinboard/endpoints_test.go
@@ -119,10 +119,8 @@ func TestSuggestTags(t *testing.T) {
 		if len(popular) != 1 || popular[0] != "go" {
 			t.Errorf("popular = %v, want [go]", popular)
 		}
-		// Documents current behavior: only the first array element is
-		// read, so recommended tags in the second element are dropped.
-		if recommended != nil {
-			t.Errorf("recommended = %v, current implementation reads only result[0]", recommended)
+		if len(recommended) != 2 || recommended[0] != "golang" || recommended[1] != "web" {
+			t.Errorf("recommended = %v, want [golang web]", recommended)
 		}
 	})
 

--- a/internal/client/pinboard/posts.go
+++ b/internal/client/pinboard/posts.go
@@ -273,6 +273,8 @@ func (c *Client) SuggestTags(ctx context.Context, urlParam string) ([]string, []
 	}
 	defer resp.Body.Close()
 
+	// The API returns popular and recommended tags as separate elements of
+	// one array: [{"popular": [...]}, {"recommended": [...]}].
 	var result []struct {
 		Popular     []string `json:"popular"`
 		Recommended []string `json:"recommended"`
@@ -282,9 +284,12 @@ func (c *Client) SuggestTags(ctx context.Context, urlParam string) ([]string, []
 		return nil, nil, fmt.Errorf("failed to decode suggest response: %w", err)
 	}
 
-	if len(result) == 0 {
-		return []string{}, []string{}, nil
+	popular := []string{}
+	recommended := []string{}
+	for _, entry := range result {
+		popular = append(popular, entry.Popular...)
+		recommended = append(recommended, entry.Recommended...)
 	}
 
-	return result[0].Popular, result[0].Recommended, nil
+	return popular, recommended, nil
 }


### PR DESCRIPTION
## Summary

Follow-up to the finding flagged in #44: the `posts/suggest` endpoint returns popular and recommended tags as **separate elements of one array** (`[{"popular": [...]}, {"recommended": [...]}]`), but `SuggestTags` read only `result[0]` — so the `recommended` slice it returned was always nil.

## Changes

- Collect both fields across all array elements. This handles the real two-element shape, is robust to either ordering, and still returns non-nil empty slices for an empty response.
- Update the #44 test that documented the old behavior (it asserted `recommended == nil` with a comment saying to update it when fixed) to assert the recommended tags come through.

## Testing

- `go test ./internal/client/...` — all pass; the updated assertion fails against the old code.
- `make test` — full suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018cJAFQYxY1dkbd376Ahqtr

---
_Generated by [Claude Code](https://claude.ai/code/session_018cJAFQYxY1dkbd376Ahqtr)_