### PR TITLE
cmd/hbt: sort --list-tags output

### DIFF
--- a/cmd/hbt/main.go
+++ b/cmd/hbt/main.go
@@ -3,8 +3,10 @@ package main
 import (
 	"flag"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/henrytill/hbt-go/internal"
@@ -192,7 +194,7 @@ func main() {
 			}
 		}
 		fmt.Println("Tags found:")
-		for tag := range tags {
+		for _, tag := range slices.Sorted(maps.Keys(tags)) {
 			fmt.Printf("  %s\n", tag)
 		}
 		return

--- a/test/cli_flags_test.go
+++ b/test/cli_flags_test.go
@@ -157,3 +157,17 @@ func TestCLIErrors(t *testing.T) {
 		})
 	}
 }
+
+func TestCLIListTags(t *testing.T) {
+	input := writeFlagsTestInput(t)
+
+	stdout, stderr, exitCode := runHbt(t, "--list-tags", input)
+	if exitCode != 0 {
+		t.Fatalf("exit %d, stderr: %s", exitCode, stderr)
+	}
+
+	want := "Tags found:\n  keep\n  old\n  shared\n"
+	if stdout != want {
+		t.Errorf("--list-tags output not sorted as expected:\ngot:\n%q\nwant:\n%q", stdout, want)
+	}
+}


### PR DESCRIPTION
## Summary

Follow-up to the gap flagged in #46: `--list-tags` printed tags in map iteration order, so the output differed on every run — unfriendly for users piping the output, and impossible to test.

## Changes

- Sort the tags before printing (`slices.Sorted(maps.Keys(...))`).
- Add the CLI integration test that the nondeterminism previously made impossible, asserting the exact sorted output. This closes the last uncovered `hbt` CLI path.

## Testing

- `go test ./test/` — new test passes (and fails against the old binary on runs where the map order differs).
- `make test` — full suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018cJAFQYxY1dkbd376Ahqtr

---
_Generated by [Claude Code](https://claude.ai/code/session_018cJAFQYxY1dkbd376Ahqtr)_