### PR TITLE
internal/parser: remove redundant initializations in saveEntity

### DIFF
--- a/internal/parser/markdown.go
+++ b/internal/parser/markdown.go
@@ -41,17 +41,12 @@ func saveEntity(state *parserState, linkURL, linkTitle string) (types.Id, error)
 	}
 
 	if linkTitle != "" {
-		entity.Names = map[types.Name]struct{}{types.Name(linkTitle): {}}
-	} else {
-		entity.Names = make(map[types.Name]struct{})
+		entity.Names[types.Name(linkTitle)] = struct{}{}
 	}
 
-	entity.Labels = make(map[types.Label]struct{})
-	if len(state.labels) > 0 {
-		for _, label := range state.labels {
-			if trimmedLabel := strings.TrimSpace(label); trimmedLabel != "" {
-				entity.Labels[types.Label(trimmedLabel)] = struct{}{}
-			}
+	for _, label := range state.labels {
+		if trimmedLabel := strings.TrimSpace(label); trimmedLabel != "" {
+			entity.Labels[types.Label(trimmedLabel)] = struct{}{}
 		}
 	}
 


### PR DESCRIPTION
## Summary

Cleanup from the review: in the markdown parser's `saveEntity`, `Names` and `Labels` were each initialized **three times** — once in the `Entity` composite literal, then immediately reassigned (twice, in `Labels`' case via an unconditional overwrite). The label loop was also wrapped in a redundant `len(...) > 0` check that ranging already handles.

## Changes

Behavior-preserving simplification: initialize the maps once in the literal and fill them in place.

## Testing

- `make test` — full suite passes, including all 22 markdown golden cases (byte-identical output).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018cJAFQYxY1dkbd376Ahqtr

---
_Generated by [Claude Code](https://claude.ai/code/session_018cJAFQYxY1dkbd376Ahqtr)_