### PR TITLE
cmd: tidy input/output file handling and version output

### DIFF
--- a/cmd/hbt/main.go
+++ b/cmd/hbt/main.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
+	"io/fs"
 	"maps"
 	"os"
 	"path/filepath"
@@ -58,6 +60,9 @@ func showUsage() {
 
 func showVersion() {
 	fmt.Printf("hbt %s\n", Version)
+	if Commit != "unknown" {
+		fmt.Printf("  commit: %s (%s, %s)\n", Commit, CommitDate, TreeState)
+	}
 }
 
 func detectInputFormat(filename string) (Format, error) {
@@ -152,14 +157,13 @@ func main() {
 		os.Exit(1)
 	}
 
-	if _, err := os.Stat(config.InputFile); os.IsNotExist(err) {
-		fmt.Fprintf(os.Stderr, "Error: Input file does not exist: %s\n", config.InputFile)
-		os.Exit(1)
-	}
-
 	inputFile, err := os.Open(config.InputFile)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error opening input file: %v\n", err)
+		if errors.Is(err, fs.ErrNotExist) {
+			fmt.Fprintf(os.Stderr, "Error: Input file does not exist: %s\n", config.InputFile)
+		} else {
+			fmt.Fprintf(os.Stderr, "Error opening input file: %v\n", err)
+		}
 		os.Exit(1)
 	}
 	defer inputFile.Close()
@@ -185,11 +189,11 @@ func main() {
 	}
 
 	if *config.ListTags {
-		tags := make(map[string]bool)
+		tags := make(map[string]struct{})
 		for _, entity := range coll.Entities() {
 			for label := range entity.Labels {
 				if string(label) != "" {
-					tags[string(label)] = true
+					tags[string(label)] = struct{}{}
 				}
 			}
 		}
@@ -201,22 +205,28 @@ func main() {
 	}
 
 	if config.OutputFormat.Format.Name != "" {
-		var output *os.File
+		output := os.Stdout
 		if *config.OutputFile != "" {
 			output, err = os.Create(*config.OutputFile)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Error creating output file: %v\n", err)
 				os.Exit(1)
 			}
-			defer output.Close()
-		} else {
-			output = os.Stdout
 		}
 
 		err = internal.Unparse(config.OutputFormat.Format, output, &coll)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error formatting output: %v\n", err)
 			os.Exit(1)
+		}
+
+		// Close errors on the output file mean data may not have reached
+		// disk; unlike the read side, they must not be ignored.
+		if output != os.Stdout {
+			if err := output.Close(); err != nil {
+				fmt.Fprintf(os.Stderr, "Error closing output file: %v\n", err)
+				os.Exit(1)
+			}
 		}
 	}
 }

--- a/cmd/pinboard/main.go
+++ b/cmd/pinboard/main.go
@@ -17,6 +17,9 @@ var (
 
 func showVersion() {
 	fmt.Printf("pinboard %s\n", Version)
+	if Commit != "unknown" {
+		fmt.Printf("  commit: %s (%s, %s)\n", Commit, CommitDate, TreeState)
+	}
 }
 
 func showUsage() {


### PR DESCRIPTION
## Summary

The remaining small idiomaticity items from the review, all in the commands:

- **Drop the `os.Stat` pre-check** before opening the input file (a time-of-check/time-of-use race and a redundant syscall). The open error is classified with `errors.Is(err, fs.ErrNotExist)` instead, preserving the exact "does not exist" message the CLI tests assert.
- **Check the output file's `Close` error** instead of deferring it away — a failed close on the write side means data may not have reached disk and now exits non-zero with a message. stdout is exempt.
- **Print `Commit`/`CommitDate`/`TreeState` in `--version`** (both `hbt` and `pinboard`): the SLSA release workflow injects all four via ldflags, but the three beyond `Version` were declared and never read. Dev builds are unchanged (`hbt 0.1.0-dev`); release builds gain a second line:
  ```
  hbt 0.1.0
    commit: abc123 (1719960000, clean)
  ```
- **`map[string]struct{}`** for the `--list-tags` set.

## Testing

- Verified by hand: missing-file error message unchanged, `-V` output unchanged for dev builds, and a build with `-ldflags "-X main.Commit=..."` prints the commit line.
- `make test` — full suite passes, including the CLI error-path tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018cJAFQYxY1dkbd376Ahqtr

---
_Generated by [Claude Code](https://claude.ai/code/session_018cJAFQYxY1dkbd376Ahqtr)_