### PR TITLE
internal/types: return an iterator from Collection.Entities

### DIFF
--- a/cmd/hbt/main.go
+++ b/cmd/hbt/main.go
@@ -190,7 +190,7 @@ func main() {
 
 	if *config.ListTags {
 		tags := make(map[string]struct{})
-		for _, entity := range coll.Entities() {
+		for entity := range coll.Entities() {
 			for label := range entity.Labels {
 				if string(label) != "" {
 					tags[string(label)] = struct{}{}

--- a/internal/formatter/html.go
+++ b/internal/formatter/html.go
@@ -143,7 +143,7 @@ func (f *HTMLFormatter) Format(writer io.Writer, coll *types.Collection) error {
 		Entities: make([]templateEntity, 0, coll.Len()),
 	}
 
-	for _, entity := range coll.Entities() {
+	for entity := range coll.Entities() {
 		templateEntity := newTemplateEntity(entity)
 		templateData.Entities = append(templateData.Entities, templateEntity)
 	}

--- a/internal/formatter/html_test.go
+++ b/internal/formatter/html_test.go
@@ -2,6 +2,7 @@ package formatter
 
 import (
 	"net/url"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -107,7 +108,7 @@ func TestHTMLFormatterRoundTrip(t *testing.T) {
 		t.Fatalf("expected 1 entity after round trip, got %d", reparsed.Len())
 	}
 
-	got := reparsed.Entities()[0]
+	got := slices.Collect(reparsed.Entities())[0]
 	if got.URI.String() != original.URI.String() {
 		t.Errorf("URI: got %q, want %q", got.URI.String(), original.URI.String())
 	}

--- a/internal/parser/html_test.go
+++ b/internal/parser/html_test.go
@@ -25,7 +25,11 @@ func parseSingleBookmark(t *testing.T, anchor string) types.Entity {
 	if coll.Len() != 1 {
 		t.Fatalf("expected 1 entity, got %d", coll.Len())
 	}
-	return coll.Entities()[0]
+	for e := range coll.Entities() {
+		return e
+	}
+	t.Fatal("no entity parsed")
+	return types.Entity{}
 }
 
 func labelSet(e types.Entity) map[string]struct{} {

--- a/internal/types/collection.go
+++ b/internal/types/collection.go
@@ -3,7 +3,9 @@ package types
 import (
 	"encoding/json"
 	"fmt"
+	"iter"
 	"net/url"
+	"slices"
 
 	"github.com/henrytill/hbt-go/internal/pinboard"
 	"golang.org/x/mod/semver"
@@ -106,8 +108,12 @@ func (c *Collection) Len() int {
 	return len(c.entities)
 }
 
-func (c *Collection) Entities() []Entity {
-	return c.entities
+// Entities returns an iterator over the collection's entities in insertion
+// order. The yielded values are copies, so the collection's structure cannot
+// be modified through them, but they share interior maps and slices (Names,
+// Labels, Extended) with the collection.
+func (c *Collection) Entities() iter.Seq[Entity] {
+	return slices.Values(c.entities)
 }
 
 type Version string

--- a/internal/types/entity_test.go
+++ b/internal/types/entity_test.go
@@ -82,6 +82,15 @@ func entityAt(uri string, unix int64) Entity {
 	}
 }
 
+func firstEntity(t *testing.T, coll Collection) Entity {
+	t.Helper()
+	for e := range coll.Entities() {
+		return e
+	}
+	t.Fatal("collection is empty")
+	return Entity{}
+}
+
 func TestUpsertInsertsDistinctURIs(t *testing.T) {
 	coll := NewCollection()
 
@@ -123,7 +132,7 @@ func TestUpsertMergesSameURI(t *testing.T) {
 		t.Error("upserting the same URI should return the same id")
 	}
 
-	got := coll.Entities()[0]
+	got := firstEntity(t, coll)
 
 	if names := MapToSortedSlice(got.Names); !slices.Equal(names, []string{"First", "Second"}) {
 		t.Errorf("Names = %v, want union [First Second]", names)
@@ -151,7 +160,7 @@ func TestUpsertKeepsEarliestCreatedAt(t *testing.T) {
 		coll.Upsert(entityAt("https://example.com/", 100))
 		coll.Upsert(entityAt("https://example.com/", 200))
 
-		got := coll.Entities()[0]
+		got := firstEntity(t, coll)
 		if got.CreatedAt.Unix() != 100 {
 			t.Errorf("CreatedAt = %d, want 100 (earliest)", got.CreatedAt.Unix())
 		}
@@ -165,7 +174,7 @@ func TestUpsertKeepsEarliestCreatedAt(t *testing.T) {
 		coll.Upsert(entityAt("https://example.com/", 200))
 		coll.Upsert(entityAt("https://example.com/", 100))
 
-		got := coll.Entities()[0]
+		got := firstEntity(t, coll)
 		if got.CreatedAt.Unix() != 100 {
 			t.Errorf("CreatedAt = %d, want 100 (earliest)", got.CreatedAt.Unix())
 		}
@@ -180,7 +189,7 @@ func TestUpsertKeepsEarliestCreatedAt(t *testing.T) {
 		coll.Upsert(entityAt("https://example.com/", 100))
 		coll.Upsert(entityAt("https://example.com/", 200))
 
-		got := coll.Entities()[0]
+		got := firstEntity(t, coll)
 		if got.CreatedAt.Unix() != 100 {
 			t.Errorf("CreatedAt = %d, want 100 (earliest)", got.CreatedAt.Unix())
 		}
@@ -198,7 +207,7 @@ func TestUpsertKeepsEarliestCreatedAt(t *testing.T) {
 		coll.Upsert(entityAt("https://example.com/", 100))
 		coll.Upsert(entityAt("https://example.com/", 100))
 
-		got := coll.Entities()[0]
+		got := firstEntity(t, coll)
 		if len(got.UpdatedAt) != 0 {
 			t.Errorf("UpdatedAt = %v, want empty for identical timestamps", got.UpdatedAt)
 		}
@@ -218,7 +227,7 @@ func TestApplyMappings(t *testing.T) {
 		"alias": "new", // two labels collapsing into one
 	})
 
-	labels := MapToSortedSlice(coll.Entities()[0].Labels)
+	labels := MapToSortedSlice(firstEntity(t, coll).Labels)
 	if !slices.Equal(labels, []string{"keep", "new"}) {
 		t.Errorf("Labels = %v, want [keep new]", labels)
 	}


### PR DESCRIPTION
## Summary

`Entities()` returned the collection's backing slice, so callers could append to, reorder, or replace entities behind the collection's `urls` index. It now returns an `iter.Seq[Entity]` (via `slices.Values`), matching the stdlib's iterator direction and `Vec.All` in this repo.

As discussed: this is an **encapsulation improvement rather than true immutability** — the yielded values are copies, so the collection's structure can't be modified through them, but they share interior maps and slices (`Names`, `Labels`, `Extended`) with the collection. The doc comment states this explicitly.

Performance-wise this is a non-event: the only cost is the range-over-func indirect call (a few ns per element, invisible next to per-entity formatting work), and it's strictly cheaper than the defensive-copy alternative.

## Changes

- `Collection.Entities()` returns `iter.Seq[Entity]`; documented semantics.
- Both production call sites (`formatter/html.go`, `cmd/hbt --list-tags`) switch from `for _, e := range` to `for e := range`.
- Tests that indexed `Entities()[0]` use a small `firstEntity` helper (types package) or `slices.Collect` (formatter round-trip test).

## Testing

- `make test` — full suite passes; HTML golden output byte-identical (iteration order unchanged: insertion order, as before).

**Note:** may conflict trivially with #52 in the `--list-tags` block (adjacent lines); if so, whichever merges second is a one-line rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018cJAFQYxY1dkbd376Ahqtr

---
_Generated by [Claude Code](https://claude.ai/code/session_018cJAFQYxY1dkbd376Ahqtr)_